### PR TITLE
Move to using PrismLauncher's meta as upstream

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -19,6 +19,6 @@ jobs:
           target_sync_branch: master
           target_repo_token: ${{ secrets.GITHUB_TOKEN }}
           upstream_sync_branch: master
-          upstream_sync_repo: PolyMC/meta-polymc
+          upstream_sync_repo: PrismLauncher/meta-polymc
           upstream_repo_access_token: ${{ secrets.GITHUB_TOKEN }}
           test_mode: false


### PR DESCRIPTION
With the whole downfall of PolyMC, PrismLauncher has come from the ashes. They're the other maintainers who were knocked out. As I still use ManyMC's meta server due to running M1 Macs on the go it looks like this meta will be stagnant from Minecraft updates. This PR changes the upstream to PrismLauncher's meta repo. 